### PR TITLE
ci: skip CI on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Related Issue

Closes #6

## Changes

Remove the `push` trigger from CI workflow. Code is already tested on the PR branch before merge, so running again on main is redundant.

## Checklist

- [x] Linked to an existing issue
- [x] Rebased on `main`, squashed into a single commit
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Added/updated tests if applicable