### PR TITLE
deps: update reqwest from 0.12 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["security", "vulnerabilities", "euvd", "enisa", "cve"]
 categories = ["api-bindings"]
 
 [dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 tokio = { version = "1.42", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Related Issue

Closes #8

## Changes

Update reqwest from 0.12 to 0.13. The `rustls-tls` feature was renamed to `rustls` in this release.

## Checklist

- [x] Linked to an existing issue
- [x] Rebased on `main`, squashed into a single commit
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Added/updated tests if applicable