### PR TITLE
feat: add example CLI for common lookup workflows

### DIFF
--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -1,0 +1,112 @@
+use euvd_rs::{EuvdClient, SearchParams};
+use std::env;
+
+#[tokio::main]
+async fn main() -> euvd_rs::Result<()> {
+    let client = EuvdClient::new();
+
+    let args: Vec<String> = env::args().collect();
+    let command = args.get(1).map(|s| s.as_str()).unwrap_or("latest");
+
+    match command {
+        "latest" => {
+            let vulns = client.latest_vulnerabilities().await?;
+            println!("Latest vulnerabilities ({} results):\n", vulns.len());
+            for v in &vulns {
+                println!(
+                    "  {} (CVSS {:.1}) - {}",
+                    v.id,
+                    v.base_score,
+                    truncate(&v.description, 80)
+                );
+            }
+        }
+        "exploited" => {
+            let vulns = client.exploited_vulnerabilities().await?;
+            println!("Exploited vulnerabilities ({} results):\n", vulns.len());
+            for v in &vulns {
+                let since = v.exploited_since.as_deref().unwrap_or("unknown");
+                println!(
+                    "  {} (since {}) - {}",
+                    v.id,
+                    since,
+                    truncate(&v.description, 60)
+                );
+            }
+        }
+        "critical" => {
+            let vulns = client.critical_vulnerabilities().await?;
+            println!("Critical vulnerabilities ({} results):\n", vulns.len());
+            for v in &vulns {
+                println!(
+                    "  {} (CVSS {:.1}) - {}",
+                    v.id,
+                    v.base_score,
+                    truncate(&v.description, 80)
+                );
+            }
+        }
+        "search" => {
+            let query = args.get(2).expect("Usage: lookup search <query>");
+            let params = SearchParams {
+                text: Some(query.clone()),
+                from_score: None,
+                to_score: None,
+            };
+            let vulns = client.search(&params).await?;
+            println!(
+                "Search results for '{}' ({} results):\n",
+                query,
+                vulns.len()
+            );
+            for v in &vulns {
+                println!(
+                    "  {} (CVSS {:.1}) - {}",
+                    v.id,
+                    v.base_score,
+                    truncate(&v.description, 80)
+                );
+            }
+        }
+        "id" => {
+            let id = args.get(2).expect("Usage: lookup id <EUVD-ID>");
+            let v = client.get_by_id(id).await?;
+            println!("{}", v.id);
+            println!(
+                "  Score:       {:.1} ({})",
+                v.base_score,
+                v.base_score_version.as_deref().unwrap_or("n/a")
+            );
+            println!("  Published:   {}", v.date_published);
+            println!("  Updated:     {}", v.date_updated);
+            println!("  Assigner:    {}", v.assigner);
+            println!("  EPSS:        {:.4}", v.epss);
+            if let Some(aliases) = &v.aliases {
+                println!("  Aliases:     {}", aliases.trim().replace('\n', ", "));
+            }
+            println!("  Description: {}", v.description);
+        }
+        _ => {
+            eprintln!("Usage: lookup <command> [args]");
+            eprintln!();
+            eprintln!("Commands:");
+            eprintln!("  latest              List latest vulnerabilities");
+            eprintln!("  exploited           List exploited vulnerabilities");
+            eprintln!("  critical            List critical vulnerabilities");
+            eprintln!("  search <query>      Search vulnerabilities by text");
+            eprintln!("  id <EUVD-ID>        Look up a specific vulnerability");
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let s = s.replace('\n', " ");
+    if s.len() <= max {
+        s
+    } else {
+        format!("{}...", &s[..max])
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #10

## Changes

Add `examples/lookup.rs` — a simple CLI demonstrating all public API methods:

```
cargo run --example lookup latest
cargo run --example lookup exploited
cargo run --example lookup critical
cargo run --example lookup search "Microsoft"
cargo run --example lookup id "EUVD-2024-45012"
```

## Checklist

- [x] Linked to an existing issue
- [x] Rebased on `main`, squashed into a single commit
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Added/updated tests if applicable