### PR TITLE
fix: correct search endpoint query param and response type

### DIFF
--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -1,0 +1,113 @@
+use euvd_rs::{EuvdClient, SearchParams};
+use std::env;
+
+#[tokio::main]
+async fn main() -> euvd_rs::Result<()> {
+    let client = EuvdClient::new();
+
+    let args: Vec<String> = env::args().collect();
+    let command = args.get(1).map(|s| s.as_str()).unwrap_or("latest");
+
+    match command {
+        "latest" => {
+            let vulns = client.latest_vulnerabilities().await?;
+            println!("Latest vulnerabilities ({} results):\n", vulns.len());
+            for v in &vulns {
+                println!(
+                    "  {} (CVSS {:.1}) - {}",
+                    v.id,
+                    v.base_score,
+                    truncate(&v.description, 80)
+                );
+            }
+        }
+        "exploited" => {
+            let vulns = client.exploited_vulnerabilities().await?;
+            println!("Exploited vulnerabilities ({} results):\n", vulns.len());
+            for v in &vulns {
+                let since = v.exploited_since.as_deref().unwrap_or("unknown");
+                println!(
+                    "  {} (since {}) - {}",
+                    v.id,
+                    since,
+                    truncate(&v.description, 60)
+                );
+            }
+        }
+        "critical" => {
+            let vulns = client.critical_vulnerabilities().await?;
+            println!("Critical vulnerabilities ({} results):\n", vulns.len());
+            for v in &vulns {
+                println!(
+                    "  {} (CVSS {:.1}) - {}",
+                    v.id,
+                    v.base_score,
+                    truncate(&v.description, 80)
+                );
+            }
+        }
+        "search" => {
+            let query = args.get(2).expect("Usage: lookup search <query>");
+            let params = SearchParams {
+                text: Some(query.clone()),
+                from_score: None,
+                to_score: None,
+            };
+            let result = client.search(&params).await?;
+            println!(
+                "Search results for '{}' ({} of {} total):\n",
+                query,
+                result.items.len(),
+                result.total
+            );
+            for v in &result.items {
+                println!(
+                    "  {} (CVSS {:.1}) - {}",
+                    v.id,
+                    v.base_score,
+                    truncate(&v.description, 80)
+                );
+            }
+        }
+        "id" => {
+            let id = args.get(2).expect("Usage: lookup id <EUVD-ID>");
+            let v = client.get_by_id(id).await?;
+            println!("{}", v.id);
+            println!(
+                "  Score:       {:.1} ({})",
+                v.base_score,
+                v.base_score_version.as_deref().unwrap_or("n/a")
+            );
+            println!("  Published:   {}", v.date_published);
+            println!("  Updated:     {}", v.date_updated);
+            println!("  Assigner:    {}", v.assigner);
+            println!("  EPSS:        {:.4}", v.epss);
+            if let Some(aliases) = &v.aliases {
+                println!("  Aliases:     {}", aliases.trim().replace('\n', ", "));
+            }
+            println!("  Description: {}", v.description);
+        }
+        _ => {
+            eprintln!("Usage: lookup <command> [args]");
+            eprintln!();
+            eprintln!("Commands:");
+            eprintln!("  latest              List latest vulnerabilities");
+            eprintln!("  exploited           List exploited vulnerabilities");
+            eprintln!("  critical            List critical vulnerabilities");
+            eprintln!("  search <query>      Search vulnerabilities by text");
+            eprintln!("  id <EUVD-ID>        Look up a specific vulnerability");
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let s = s.replace('\n', " ");
+    if s.len() <= max {
+        s
+    } else {
+        format!("{}...", &s[..max])
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{EuvdError, Result},
-    models::{CveEuvdMapping, Vulnerability, VulnerabilityList},
+    models::{CveEuvdMapping, SearchResponse, Vulnerability, VulnerabilityList},
     rate_limiter::RateLimiter,
 };
 use reqwest::Client;
@@ -75,12 +75,12 @@ impl EuvdClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn search(&self, params: &SearchParams) -> Result<VulnerabilityList> {
+    pub async fn search(&self, params: &SearchParams) -> Result<SearchResponse> {
         let mut url = format!("{}/search", self.base_url);
         let mut query_parts = Vec::new();
 
         if let Some(text) = &params.text {
-            query_parts.push(format!("text={}", urlencoding::encode(text)));
+            query_parts.push(format!("search={}", urlencoding::encode(text)));
         }
         if let Some(from_score) = params.from_score {
             query_parts.push(format!("fromScore={}", from_score));
@@ -156,7 +156,7 @@ impl EuvdClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_by_cve(&self, cve_id: &str) -> Result<VulnerabilityList> {
+    pub async fn get_by_cve(&self, cve_id: &str) -> Result<SearchResponse> {
         self.search(&SearchParams {
             text: Some(cve_id.to_string()),
             from_score: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,4 +36,4 @@ mod rate_limiter;
 
 pub use client::{EuvdClient, EuvdClientBuilder, SearchParams};
 pub use error::{EuvdError, Result};
-pub use models::{CveEuvdMapping, Vulnerability, VulnerabilityList};
+pub use models::{CveEuvdMapping, SearchResponse, Vulnerability, VulnerabilityList};

--- a/src/models.rs
+++ b/src/models.rs
@@ -139,6 +139,15 @@ pub struct AdvisoryRelation {
 /// List of vulnerabilities
 pub type VulnerabilityList = Vec<Vulnerability>;
 
+/// Paginated search response from the EUVD search endpoint
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SearchResponse {
+    /// Matching vulnerabilities
+    pub items: Vec<Vulnerability>,
+    /// Total number of matching results
+    pub total: u64,
+}
+
 /// A mapping between a CVE ID and an EUVD ID from the bulk dump endpoint
 #[derive(Clone, Debug, PartialEq)]
 pub struct CveEuvdMapping {

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -12,7 +12,7 @@ async fn test_rate_limit_zero_does_not_panic() {
 #[tokio::test]
 async fn test_client_builder_default() {
     let client = EuvdClient::builder().build();
-    assert_eq!(format!("{:?}", client).contains("EuvdClient"), true);
+    assert!(format!("{:?}", client).contains("EuvdClient"));
 }
 
 #[tokio::test]
@@ -20,13 +20,13 @@ async fn test_client_builder_custom_base_url() {
     let client = EuvdClient::builder()
         .base_url("https://example.com/api")
         .build();
-    assert_eq!(format!("{:?}", client).contains("EuvdClient"), true);
+    assert!(format!("{:?}", client).contains("EuvdClient"));
 }
 
 #[tokio::test]
 async fn test_client_builder_custom_rate_limit() {
     let client = EuvdClient::builder().rate_limit(5).build();
-    assert_eq!(format!("{:?}", client).contains("EuvdClient"), true);
+    assert!(format!("{:?}", client).contains("EuvdClient"));
 }
 
 #[tokio::test]
@@ -194,11 +194,11 @@ async fn test_get_by_id_not_found() {
 #[tokio::test]
 async fn test_search_with_text() {
     let mut server = Server::new_async().await;
-    let fixture = include_str!("fixtures/latest_vulnerabilities.json");
+    let fixture = include_str!("fixtures/search_response.json");
 
     let mock = server
         .mock("GET", "/search")
-        .match_query(Matcher::UrlEncoded("text".into(), "Microsoft".into()))
+        .match_query(Matcher::UrlEncoded("search".into(), "linux".into()))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(fixture)
@@ -208,13 +208,14 @@ async fn test_search_with_text() {
     let client = EuvdClient::builder().base_url(server.url()).build();
 
     let params = SearchParams {
-        text: Some("Microsoft".to_string()),
+        text: Some("linux".to_string()),
         from_score: None,
         to_score: None,
     };
 
-    let result = client.search(&params).await;
-    assert!(result.is_ok());
+    let result = client.search(&params).await.unwrap();
+    assert_eq!(result.total, 2);
+    assert_eq!(result.items.len(), 2);
 
     mock.assert_async().await;
 }
@@ -222,7 +223,7 @@ async fn test_search_with_text() {
 #[tokio::test]
 async fn test_search_with_score_range() {
     let mut server = Server::new_async().await;
-    let fixture = include_str!("fixtures/critical_vulnerabilities.json");
+    let fixture = include_str!("fixtures/search_response.json");
 
     let mock = server
         .mock("GET", "/search")
@@ -244,8 +245,8 @@ async fn test_search_with_score_range() {
         to_score: Some(10),
     };
 
-    let result = client.search(&params).await;
-    assert!(result.is_ok());
+    let result = client.search(&params).await.unwrap();
+    assert_eq!(result.items.len(), 2);
 
     mock.assert_async().await;
 }
@@ -253,11 +254,11 @@ async fn test_search_with_score_range() {
 #[tokio::test]
 async fn test_get_by_cve() {
     let mut server = Server::new_async().await;
-    let fixture = include_str!("fixtures/latest_vulnerabilities.json");
+    let fixture = include_str!("fixtures/search_response.json");
 
     let mock = server
         .mock("GET", "/search")
-        .match_query(Matcher::UrlEncoded("text".into(), "CVE-2023-6425".into()))
+        .match_query(Matcher::UrlEncoded("search".into(), "CVE-2023-6425".into()))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(fixture)
@@ -266,8 +267,8 @@ async fn test_get_by_cve() {
 
     let client = EuvdClient::builder().base_url(server.url()).build();
 
-    let result = client.get_by_cve("CVE-2023-6425").await;
-    assert!(result.is_ok());
+    let result = client.get_by_cve("CVE-2023-6425").await.unwrap();
+    assert_eq!(result.items.len(), 2);
 
     mock.assert_async().await;
 }

--- a/tests/fixtures/search_response.json
+++ b/tests/fixtures/search_response.json
@@ -1,0 +1,74 @@
+{
+  "items": [
+    {
+      "id": "EUVD-2019-19884",
+      "enisaUuid": "286c4554-48d9-3fea-9a1f-0c6c5707e293",
+      "description": "Memu Play 6.0.7 contains an insecure file permissions vulnerability that allows low-privilege users to escalate privileges by replacing the MemuService.exe executable. Attackers can rename and overwrite MemuService.exe in the installation directory with a malicious executable, which executes with system-level privileges when the service restarts after a computer reboot.",
+      "datePublished": "Mar 21, 2026, 3:33:24 PM",
+      "dateUpdated": "Mar 21, 2026, 3:33:24 PM",
+      "baseScore": 9.3,
+      "baseScoreVersion": "4.0",
+      "baseScoreVector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+      "references": "https://www.exploit-db.com/exploits/46437\nhttps://www.memuplay.com/\nhttps://www.memuplay.com/download-en.php?file_name=Memu-Setup&from=official_release\nhttps://www.vulncheck.com/advisories/memu-play-privilege-escalation-via-insecure-file-permissions\nhttps://nvd.nist.gov/vuln/detail/CVE-2019-25568\n",
+      "aliases": "CVE-2019-25568\nGHSA-p3g8-9x5j-gq4j\n",
+      "assigner": "VulnCheck",
+      "epss": 0.0,
+      "enisaIdProduct": [
+        {
+          "id": "2f42227f-c8ee-3df9-9b31-ec831d34aff0",
+          "product": {
+            "name": "MEMU PLAY"
+          },
+          "product_version": "6.0.7"
+        },
+        {
+          "id": "8dd37a36-aa9b-3399-8236-4873f28990c9",
+          "product": {
+            "name": "MEMU PLAY"
+          },
+          "product_version": "6.0.7"
+        }
+      ],
+      "enisaIdVendor": [
+        {
+          "id": "259a4293-67c2-308e-94a6-cdb525f6a0db",
+          "vendor": {
+            "name": "Memuplay"
+          }
+        }
+      ]
+    },
+    {
+      "id": "EUVD-2026-13840",
+      "enisaUuid": "2a92e9b8-ee24-38e5-90b2-8b70800a3bc0",
+      "description": "Service information is not encrypted when transmitted as BACnet packets \nover the wire, and can be sniffed, intercepted, and modified by an \nattacker. Valuable information such as the File Start Position and File \nData can be sniffed from network traffic using Wireshark's BACnet \ndissector filter. The proprietary format used by WebCTRL to receive \nupdates from the PLC can also be sniffed and reverse engineered.",
+      "datePublished": "Mar 21, 2026, 12:31:44 AM",
+      "dateUpdated": "Mar 21, 2026, 12:31:44 AM",
+      "baseScore": 9.1,
+      "baseScoreVersion": "3.1",
+      "baseScoreVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+      "references": "https://www.automatedlogic.com/en/company/security-commitment/\nhttps://www.cisa.gov/news-events/ics-advisories/icsa-26-078-08\nhttps://github.com/cisagov/CSAF/blob/develop/csaf_files/OT/white/2026/icsa-26-078-08.json\nhttps://nvd.nist.gov/vuln/detail/CVE-2026-24060\n",
+      "aliases": "CVE-2026-24060\n",
+      "assigner": "icscert",
+      "epss": 0.02,
+      "enisaIdProduct": [
+        {
+          "id": "6bd26d65-6a04-3c6c-a675-00470cb30a27",
+          "product": {
+            "name": "WebCTRL Premium Server"
+          },
+          "product_version": "0 <v8.5"
+        }
+      ],
+      "enisaIdVendor": [
+        {
+          "id": "30b216e7-1fc2-3e37-b8df-a630f125c73f",
+          "vendor": {
+            "name": "Automated Logic"
+          }
+        }
+      ]
+    }
+  ],
+  "total": 2
+}


### PR DESCRIPTION
## Related Issue

Closes #12
Closes #10

## Changes

- Fix search query parameter from `text=` to `search=` (matching the actual API)
- Add `SearchResponse` type for the paginated `{"items": [...], "total": N}` response
- Update `search()` and `get_by_cve()` return types to `SearchResponse`
- Add `search_response.json` test fixture captured from the live API
- Update all search-related tests to verify the correct query param and response shape
- Add `examples/lookup.rs` CLI demonstrating all public API methods

## Checklist

- [x] Linked to an existing issue
- [x] Rebased on `main`, squashed into a single commit
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Added/updated tests if applicable